### PR TITLE
Change Sig to G2 (96bytes) and PubKey to G1 (48bytes)

### DIFF
--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -1,6 +1,6 @@
 extern crate amcl;
 
-use super::amcl_utils::{ate_pairing, hash_on_g1, GeneratorG2};
+use super::amcl_utils::{ate_pairing, hash_on_g2, GeneratorG1};
 use super::errors::DecodeError;
 use super::g1::G1Point;
 use super::g2::G2Point;
@@ -12,7 +12,7 @@ use super::signature::Signature;
 /// This may be used to verify some AggregateSignature.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AggregatePublicKey {
-    pub point: G2Point,
+    pub point: G1Point,
 }
 
 impl AggregatePublicKey {
@@ -20,7 +20,7 @@ impl AggregatePublicKey {
     ///
     /// The underlying point will be set to infinity.
     pub fn new() -> Self {
-        let mut point = G2Point::new();
+        let mut point = G1Point::new();
         // TODO: check why this inf call
         point.inf();
         Self { point }
@@ -46,7 +46,7 @@ impl AggregatePublicKey {
     ///
     /// TODO: detail the exact format of these bytes (e.g., compressed, etc).
     pub fn from_bytes(bytes: &[u8]) -> Result<AggregatePublicKey, DecodeError> {
-        let point = G2Point::from_bytes(bytes)?;
+        let point = G1Point::from_bytes(bytes)?;
         Ok(Self { point })
     }
 
@@ -69,7 +69,7 @@ impl Default for AggregatePublicKey {
 /// This may be verified against some AggregatePublicKey.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AggregateSignature {
-    pub point: G1Point,
+    pub point: G2Point,
 }
 
 impl AggregateSignature {
@@ -77,7 +77,7 @@ impl AggregateSignature {
     ///
     /// The underlying point will be set to infinity.
     pub fn new() -> Self {
-        let mut point = G1Point::new();
+        let mut point = G2Point::new();
         // TODO: check why this inf call
         point.inf();
         Self { point }
@@ -100,9 +100,9 @@ impl AggregateSignature {
         let mut key_point = avk.point.clone();
         sig_point.affine();
         key_point.affine();
-        let msg_hash_point = hash_on_g1(msg);
-        let mut lhs = ate_pairing(&GeneratorG2, sig_point.as_raw());
-        let mut rhs = ate_pairing(&key_point.as_raw(), &msg_hash_point);
+        let msg_hash_point = hash_on_g2(msg);
+        let mut lhs = ate_pairing(sig_point.as_raw(), &GeneratorG1);
+        let mut rhs = ate_pairing(&msg_hash_point, &key_point.as_raw());
         lhs.equals(&mut rhs)
     }
 
@@ -110,7 +110,7 @@ impl AggregateSignature {
     ///
     /// TODO: detail the exact format of these bytes (e.g., compressed, etc).
     pub fn from_bytes(bytes: &[u8]) -> Result<AggregateSignature, DecodeError> {
-        let point = G1Point::from_bytes(bytes)?;
+        let point = G2Point::from_bytes(bytes)?;
         Ok(Self { point })
     }
 

--- a/src/amcl_utils.rs
+++ b/src/amcl_utils.rs
@@ -32,13 +32,13 @@ lazy_static! {
     pub static ref GeneratorG2: GroupG2 = GroupG2::generator();
 }
 
-pub fn hash_on_g1(msg: &[u8]) -> GroupG1 {
+pub fn hash_on_g2(msg: &[u8]) -> GroupG2 {
     let result = blake2b(49, &[], &msg);
-    GroupG1::mapit(&result.as_bytes())
+    GroupG2::mapit(&result.as_bytes())
 }
 
-pub fn map_to_g1(val: &[u8]) -> GroupG1 {
-    GroupG1::mapit(val)
+pub fn map_to_g2(val: &[u8]) -> GroupG2 {
+    GroupG2::mapit(val)
 }
 
 pub fn ate_pairing(point_g2: &GroupG2, point_g1: &GroupG1) -> FP12 {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,9 +1,9 @@
 extern crate amcl;
 extern crate rand;
 
-use super::amcl_utils::{BigNum, GeneratorG2, CURVE_ORDER, MODBYTES, MOD_BYTE_SIZE};
+use super::amcl_utils::{BigNum, GeneratorG1, CURVE_ORDER, MODBYTES, MOD_BYTE_SIZE};
 use super::errors::DecodeError;
-use super::g2::G2Point;
+use super::g1::G1Point;
 use super::rng::get_seeded_rng;
 use std::fmt;
 
@@ -59,20 +59,20 @@ impl Eq for SecretKey {}
 /// A BLS public key.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PublicKey {
-    pub point: G2Point,
+    pub point: G1Point,
 }
 
 impl PublicKey {
     /// Instantiate a PublicKey from some SecretKey.
     pub fn from_secret_key(sk: &SecretKey) -> Self {
         PublicKey {
-            point: G2Point::from_raw(GeneratorG2.mul(&sk.x)),
+            point: G1Point::from_raw(GeneratorG1.mul(&sk.x)),
         }
     }
 
     /// Instantiate a PublicKey from some bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<PublicKey, DecodeError> {
-        let point = G2Point::from_bytes(bytes)?;
+        let point = G1Point::from_bytes(bytes)?;
         Ok(Self { point })
     }
 


### PR DESCRIPTION
I have reverse the public key and the signature to match what is required by the Ethereum specs.

Notes: 
- This still does not fully comply with the Ethereum Specs as function `hash_to_g2()` does not incorporate an extra byte for the real and imaginary parts.
Fixing this would require either modifying the base acml code or picking a new library. For now it can be worked around.