### PR TITLE
Empty signatures decompressing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bls-aggregates"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Lovesh Harchandani <lovesh.bond@gmail.com>"]
 description = "Various signature schemes. BLS, MuSig"
 license = "MIT/Apache-2.0"
@@ -11,9 +11,9 @@ harness = false
 
 [dependencies]
 amcl = { path = "./amcl" }
+criterion = "0.2"
 hex = "0.3"
 lazy_static = "1.0"
 rand = "0.5"
 tiny-keccak = "1.4"
 yaml-rust = "0.4"
-criterion = "0.2"

--- a/benches/bls381_benches.rs
+++ b/benches/bls381_benches.rs
@@ -1,6 +1,6 @@
-extern crate hex;
-extern crate criterion;
 extern crate bls_aggregates;
+extern crate criterion;
+extern crate hex;
 
 use bls_aggregates::{AggregatePublicKey, AggregateSignature, Signature, Keypair};
 use criterion::{Benchmark, Criterion, criterion_group, criterion_main};

--- a/src/amcl_utils.rs
+++ b/src/amcl_utils.rs
@@ -256,7 +256,7 @@ pub fn decompress_g2(g2_bytes: &[u8]) -> Result<GroupG2, DecodeError> {
     // Check b_flag
     if g2_bytes[0] % u8::pow(2, 7) / u8::pow(2, 6) == 1 {
         // Point is infinity
-        return Err(DecodeError::Infinity);
+        return Ok(GroupG2::new());
     }
 
     let mut g2_bytes = g2_bytes.to_owned();

--- a/src/amcl_utils.rs
+++ b/src/amcl_utils.rs
@@ -228,6 +228,7 @@ pub fn compress_g2(g2: &mut GroupG2) -> Vec<u8> {
         let mut result: Vec<u8> = vec![0; G2_BYTE_SIZE / 2];
         // Set b_flag 1, all else 0
         result[0] += u8::pow(2,6);
+        return result;
     }
 
     // Convert point to array of bytes (x, y)

--- a/src/amcl_utils.rs
+++ b/src/amcl_utils.rs
@@ -32,18 +32,30 @@ pub const MOD_BYTE_SIZE: usize = bls381_MODBYTES;
 
 // G2_Cofactor as arrays of i64
 pub const G2_COFACTOR_HIGH: [Chunk; NLEN] = [
-  0x0153_7E29_3A66_91AE, 0x023C_72D3_67A0_BBC8, 0x0205_B2E5_A7DD_FA62,
-  0x0115_1C21_6AEA_9A28, 0x0128_76A2_02CD_91DE, 0x0105_39FC_4247_541E,
+  0x0153_7E29_3A66_91AE,
+  0x023C_72D3_67A0_BBC8,
+  0x0205_B2E5_A7DD_FA62,
+  0x0115_1C21_6AEA_9A28,
+  0x0128_76A2_02CD_91DE,
+  0x0105_39FC_4247_541E,
   0x0000_0000_5D54_3A95
 ];
 pub const G2_COFACTOR_LOW: [Chunk; NLEN] = [
-  0x031C_38E3_1C72_38E5, 0x01BB_1B9E_1BC3_1C33, 0x0000_0000_0000_0161,
-  0x0000_0000_0000_0000, 0x0000_0000_0000_0000, 0x0000_0000_0000_0000,
+  0x031C_38E3_1C72_38E5,
+  0x01BB_1B9E_1BC3_1C33,
+  0x0000_0000_0000_0161,
+  0x0000_0000_0000_0000,
+  0x0000_0000_0000_0000,
+  0x0000_0000_0000_0000,
   0x0000_0000_0000_0000
 ];
 pub const G2_COFACTOR_SHIFT: [Chunk; NLEN] = [
-  0x0000_0000_0000_0000, 0x0000_0000_0000_0000, 0x0000_0000_0000_1000,
-  0x0000_0000_0000_0000, 0x0000_0000_0000_0000, 0x0000_0000_0000_0000,
+  0x0000_0000_0000_0000,
+  0x0000_0000_0000_0000,
+  0x0000_0000_0000_1000,
+  0x0000_0000_0000_0000,
+  0x0000_0000_0000_0000,
+  0x0000_0000_0000_0000,
   0x0000_0000_0000_0000
 ];
 
@@ -227,7 +239,7 @@ pub fn compress_g2(g2: &mut GroupG2) -> Vec<u8> {
     if g2.is_infinity() {
         let mut result: Vec<u8> = vec![0; G2_BYTE_SIZE / 2];
         // Set b_flag 1, all else 0
-        result[0] += u8::pow(2,6);
+        result[0] += u8::pow(2, 6);
         return result;
     }
 
@@ -241,7 +253,7 @@ pub fn compress_g2(g2: &mut GroupG2) -> Vec<u8> {
 
     // TODO check flags (https://github.com/ethereum/eth2.0-tests/issues/20)
     // Add a_flag1 at 2^767 bit if g2.y.a is odd
-    let flags: u8 = result[0] + u8::pow(2,7) * (g2_bytes[MODBYTES * 3 - 1] % 2);
+    let flags: u8 = result[0] + u8::pow(2, 7) * (g2_bytes[MODBYTES * 3 - 1] % 2);
     result[0] = flags;
 
     result

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -40,9 +40,7 @@ impl G1Point {
     /// Instatiate the G1 point from compressed bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
         let pt = decompress_g1(&bytes)?;
-        Ok(Self {
-            point: pt,
-        })
+        Ok(Self { point: pt })
     }
 
     /// Export (serialize) the G1 point to compressed bytes.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -111,10 +111,10 @@ mod tests {
     extern crate hex;
     extern crate yaml_rust;
 
+    use self::yaml_rust::yaml;
     use super::super::amcl_utils::compress_g1;
     use super::super::signature::Signature;
     use super::*;
-    use self::yaml_rust::yaml;
     use std::{fs::File, io::prelude::*, path::PathBuf};
 
     #[test]

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -91,9 +91,9 @@ mod tests {
     extern crate hex;
     extern crate yaml_rust;
 
+    use self::yaml_rust::yaml;
     use super::super::keys::Keypair;
     use super::*;
-    use self::yaml_rust::yaml;
     use std::{fs::File, io::prelude::*, path::PathBuf};
 
     #[test]


### PR DESCRIPTION
v0.5.2

Allow compression and decompression of empty signatures.

i.e. allow conversion to and from: bytes <-> infinity point on G2

Note this is currently done through setting the b_flag which is the style of EF test_cases but not the style of Eth2.0 specs and hence will be updated after confirmation