### PR TITLE
Add more benches

### DIFF
--- a/benches/bls381_benches.rs
+++ b/benches/bls381_benches.rs
@@ -2,8 +2,8 @@ extern crate bls_aggregates;
 extern crate criterion;
 extern crate hex;
 
-use bls_aggregates::{AggregatePublicKey, AggregateSignature, Signature, Keypair};
-use criterion::{Benchmark, Criterion, criterion_group, criterion_main};
+use bls_aggregates::{AggregatePublicKey, AggregateSignature, Keypair, Signature};
+use criterion::{black_box, criterion_group, criterion_main, Benchmark, Criterion};
 
 fn compression(c: &mut Criterion) {
     let compressed_g2 = hex::decode("1351bdf582971f796bbaf6320e81251c9d28f674d720cca07ed14596b96697cf18238e0e03ebd7fc1353d885a39407e012cc74bc9f089ed9764bbceac5edba416bef5e73701288977b9cac1ccb6964269d4ebf78b4e8aa7792ba09d3e49c8e6a").unwrap();
@@ -13,7 +13,7 @@ fn compression(c: &mut Criterion) {
         "compression",
         Benchmark::new("Decompress a Signature", move |b| {
             b.iter(|| {
-                Signature::from_bytes(&compressed_g2).unwrap();
+                black_box(Signature::from_bytes(&compressed_g2).unwrap());
             })
         })
         .sample_size(100),
@@ -23,7 +23,7 @@ fn compression(c: &mut Criterion) {
         "compression",
         Benchmark::new("Compress a Signature", move |b| {
             b.iter(|| {
-                Signature::as_bytes(&mut signature);
+                black_box(Signature::as_bytes(&mut signature));
             })
         })
         .sample_size(10),
@@ -35,7 +35,7 @@ fn signing(c: &mut Criterion) {
     let sk = keypair.sk;
     let pk = keypair.pk;
 
-    let mut msg = "Some msg";
+    let msg = "Some msg";
     let domain = 42;
     let sig = Signature::new(&msg.as_bytes(), domain, &sk);
 
@@ -43,7 +43,7 @@ fn signing(c: &mut Criterion) {
         "signing",
         Benchmark::new("Create a Signature", move |b| {
             b.iter(|| {
-                Signature::new(&msg.as_bytes(), domain, &sk);
+                black_box(Signature::new(&msg.as_bytes(), domain, &sk));
             })
         })
         .sample_size(10),
@@ -53,7 +53,7 @@ fn signing(c: &mut Criterion) {
         "signing",
         Benchmark::new("Verify a Signature", move |b| {
             b.iter(|| {
-                sig.verify(&msg.as_bytes(), domain, &pk);
+                black_box(sig.verify(&msg.as_bytes(), domain, &pk));
             })
         })
         .sample_size(10),
@@ -79,7 +79,7 @@ fn aggregation(c: &mut Criterion) {
         "aggregation",
         Benchmark::new("Aggregate a PublicKey", move |b| {
             b.iter(|| {
-                aggregate_publickey.add(&pk);
+                black_box(aggregate_publickey.add(&pk));
             })
         })
         .sample_size(100),


### PR DESCRIPTION
Adds two more benchmarks:

- Verify a signature against 128 pubkeys.
- Verify a signature against 128 pubkeys where 1/2 signed one message and 1/2 signed another.

Makes no functional changes.