### PR TITLE
Remove checks against infinity for verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bls-aggregates"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Lovesh Harchandani <lovesh.bond@gmail.com>"]
 description = "Various signature schemes. BLS, MuSig"
 license = "MIT/Apache-2.0"

--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -91,10 +91,6 @@ impl AggregateSignature {
     /// All PublicKeys which signed across this AggregateSignature must be included in the
     /// AggregatePublicKey, otherwise verification will fail.
     pub fn verify(&self, msg: &[u8], d: u64, avk: &AggregatePublicKey) -> bool {
-        // Check points are valid
-        if self.point.is_infinity() || avk.point.is_infinity() {
-            return false;
-        }
         let mut sig_point = self.point.clone();
         let mut key_point = avk.point.clone();
         sig_point.affine();
@@ -111,10 +107,6 @@ impl AggregateSignature {
     ///  All PublicKeys related to a Message should be aggregated into one AggregatePublicKey.
     ///  Each AggregatePublicKey has a 1:1 ratio with a 32 byte Message.
     pub fn verify_multiple(&self, msg: &[u8], d: u64, avks: &[AggregatePublicKey]) -> bool {
-        // Check AggregateSignature point is valid
-        if self.point.is_infinity() {
-            return false;
-        }
         let mut sig_point = self.point.clone();
         sig_point.affine();
 
@@ -126,11 +118,6 @@ impl AggregateSignature {
         // Aggregate each AggregatePublicKey with a Message
         let mut lhs = FP12::new();
         for (i, key) in avks.iter().enumerate() {
-            // Check point is valid
-            if key.point.is_infinity() {
-                return false;
-            }
-
             let mut key_point = key.point.clone();
             key_point.affine();
             let mut hash_point = hash_on_g2(&msg[i * 32..(i + 1) * 32], d);

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -37,11 +37,6 @@ impl Signature {
     /// In theory, should only return true if the PublicKey matches the SecretKey used to
     /// instantiate the Signature.
     pub fn verify(&self, msg: &[u8], d: u64, pk: &PublicKey) -> bool {
-        // Check points are valid
-        if self.point.is_infinity() || pk.point.is_infinity() {
-            return false;
-        }
-
         let mut msg_hash_point = hash_on_g2(msg, d);
         msg_hash_point.affine();
         let mut lhs = ate_pairing(self.point.as_raw(), &GeneratorG1);
@@ -61,11 +56,6 @@ impl Signature {
         msg_hash_imaginary: &[u8],
         pk: &PublicKey,
     ) -> bool {
-        // Check points are valid
-        if self.point.is_infinity() || pk.point.is_infinity() {
-            return false;
-        }
-
         let mut msg_hash_point = map_to_g2(msg_hash_real, msg_hash_imaginary);
         msg_hash_point.affine();
         let mut lhs = ate_pairing(self.point.as_raw(), &GeneratorG1);


### PR DESCRIPTION
Remove the checks that point is infinity.

To allow allow verification to hold true when there is no public key or signature given, we have allow signatures and public keys to be infinity.