### PR TITLE
Fix issues with benches

### DIFF
--- a/benches/bls381_benches.rs
+++ b/benches/bls381_benches.rs
@@ -4,10 +4,10 @@ extern crate criterion;
 extern crate hex;
 
 use self::amcl::bls381 as BLSCurve;
-use BLSCurve::big::BIG;
-use BLSCurve::ecp::ECP;
 use bls_aggregates::*;
 use criterion::{black_box, criterion_group, criterion_main, Benchmark, Criterion};
+use BLSCurve::big::BIG;
+use BLSCurve::ecp::ECP;
 
 pub type BigNum = BIG;
 pub type GroupG1 = ECP;
@@ -225,7 +225,8 @@ fn aggregate_verfication_multiple_messages(c: &mut Criterion) {
                         agg_pubs[i / (n / msgs.len())].add(&pubkeys[i]);
                     }
                     let agg_pubs_refs: Vec<&AggregatePublicKey> = agg_pubs.iter().collect();
-                    let verified = agg_sig.verify_multiple(&agg_msg[..], domain, agg_pubs_refs.as_slice());
+                    let verified =
+                        agg_sig.verify_multiple(&agg_msg[..], domain, agg_pubs_refs.as_slice());
 
                     assert!(verified);
                 })

--- a/benches/bls381_benches.rs
+++ b/benches/bls381_benches.rs
@@ -64,19 +64,14 @@ fn compression_public_key(c: &mut Criterion) {
 
 fn compression_public_key_bigs(c: &mut Criterion) {
     let compressed_g1 = hex::decode("a491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a").unwrap();
-    let public_key = PublicKey::from_bytes(&compressed_g1).unwrap();
-    let mut x_bytes = [0 as u8; 48];
-    public_key.point.as_raw().clone().getx().tobytes(&mut x_bytes);
-    let mut y_bytes = [0 as u8; 48];
-    public_key.point.as_raw().clone().gety().tobytes(&mut y_bytes);
+    let mut public_key = PublicKey::from_bytes(&compressed_g1).unwrap();
+    let uncompressed_bytes = public_key.as_uncompressed_bytes();
 
     c.bench(
         "compression",
         Benchmark::new("Decompress a PublicKey from Bigs", move |b| {
             b.iter(|| {
-                let x_big = BigNum::frombytes(&x_bytes);
-                let y_big = BigNum::frombytes(&y_bytes);
-                black_box(PublicKey::new_from_raw(&GroupG1::new_bigs(&x_big, &y_big)));
+                black_box(PublicKey::from_uncompressed_bytes(&uncompressed_bytes));
             })
         })
         .sample_size(100),
@@ -86,9 +81,7 @@ fn compression_public_key_bigs(c: &mut Criterion) {
         "compression",
         Benchmark::new("Compress a PublicKey to Bigs", move |b| {
             b.iter(|| {
-                black_box(public_key.point.as_raw().clone().getx().tobytes(&mut x_bytes));
-                black_box(public_key.point.as_raw().clone().gety().tobytes(&mut y_bytes));
-
+                black_box(public_key.as_uncompressed_bytes());
             })
         })
         .sample_size(10),

--- a/benches/bls381_benches.rs
+++ b/benches/bls381_benches.rs
@@ -6,7 +6,7 @@ use bls_aggregates::*;
 use criterion::{black_box, criterion_group, criterion_main, Benchmark, Criterion};
 
 fn compression(c: &mut Criterion) {
-    let compressed_g2 = hex::decode("1351bdf582971f796bbaf6320e81251c9d28f674d720cca07ed14596b96697cf18238e0e03ebd7fc1353d885a39407e012cc74bc9f089ed9764bbceac5edba416bef5e73701288977b9cac1ccb6964269d4ebf78b4e8aa7792ba09d3e49c8e6a").unwrap();
+    let compressed_g2 = hex::decode("a666d31d7e6561371644eb9ca7dbcb87257d8fd84a09e38a7a491ce0bbac64a324aa26385aebc99f47432970399a2ecb0def2d4be359640e6dae6438119cbdc4f18e5e4496c68a979473a72b72d3badf98464412e9d8f8d2ea9b31953bb24899").unwrap();
     let mut signature = Signature::from_bytes(&compressed_g2).unwrap();
 
     c.bench(
@@ -117,7 +117,8 @@ fn aggregate_verfication(c: &mut Criterion) {
         "aggregation",
         Benchmark::new("Verifying aggregate of 128 signatures", move |b| {
             b.iter(|| {
-                let agg_pub = AggregatePublicKey::from_public_keys(&pubkeys);
+                let pubkeys_as_ref: Vec<&PublicKey> = pubkeys.iter().collect();
+                let agg_pub = AggregatePublicKey::from_public_keys(pubkeys_as_ref.as_slice());
                 let verified = agg_sig.verify(&msg[..], domain, &agg_pub);
                 assert!(verified);
             })
@@ -165,8 +166,8 @@ fn aggregate_verfication_multiple_messages(c: &mut Criterion) {
                     for i in 0..n {
                         agg_pubs[i / (n / msgs.len())].add(&pubkeys[i]);
                     }
-
-                    let verified = agg_sig.verify_multiple(&agg_msg[..], domain, &agg_pubs);
+                    let agg_pubs_refs: Vec<&AggregatePublicKey> = agg_pubs.iter().collect();
+                    let verified = agg_sig.verify_multiple(&agg_msg[..], domain, agg_pubs_refs.as_slice());
 
                     assert!(verified);
                 })

--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -1,6 +1,6 @@
 extern crate amcl;
 
-use super::amcl_utils::{ate_pairing, hash_on_g2, GeneratorG1, FP12};
+use super::amcl_utils::{ate_pairing, hash_on_g2, FP12, GENERATORG1};
 use super::errors::DecodeError;
 use super::g1::G1Point;
 use super::g2::G2Point;
@@ -109,7 +109,7 @@ impl AggregateSignature {
         key_point.affine();
         let mut msg_hash_point = hash_on_g2(msg, d);
         msg_hash_point.affine();
-        let mut lhs = ate_pairing(sig_point.as_raw(), &GeneratorG1);
+        let mut lhs = ate_pairing(sig_point.as_raw(), &GENERATORG1);
         let mut rhs = ate_pairing(&msg_hash_point, &key_point.as_raw());
         lhs.equals(&mut rhs)
     }
@@ -142,7 +142,7 @@ impl AggregateSignature {
             }
         }
 
-        let mut rhs = ate_pairing(sig_point.as_raw(), &GeneratorG1);
+        let mut rhs = ate_pairing(sig_point.as_raw(), &GENERATORG1);
         lhs.equals(&mut rhs)
     }
 
@@ -212,8 +212,8 @@ mod tests {
         let agg_sig_bytes = agg_sig.as_bytes();
         let agg_pub_bytes = agg_pub_key.as_bytes();
 
-        let mut agg_sig = AggregateSignature::from_bytes(&agg_sig_bytes).unwrap();
-        let mut agg_pub_key = AggregatePublicKey::from_bytes(&agg_pub_bytes).unwrap();
+        let agg_sig = AggregateSignature::from_bytes(&agg_sig_bytes).unwrap();
+        let agg_pub_key = AggregatePublicKey::from_bytes(&agg_pub_bytes).unwrap();
 
         assert!(agg_sig.verify(&message, domain, &agg_pub_key));
     }
@@ -594,7 +594,7 @@ mod tests {
 
             // Add each input signature to the aggregate signature
             for input in inputs {
-                let sig = input.as_str().unwrap().trim_left_matches("0x"); // String
+                let sig = input.as_str().unwrap().trim_start_matches("0x"); // String
                 let sig = hex::decode(sig).unwrap(); // Bytes
                 let sig = Signature::from_bytes(&sig).unwrap(); // Signature
                 aggregate_sig.add(&sig);
@@ -604,7 +604,7 @@ mod tests {
             let output = test_case["output"]
                 .as_str()
                 .unwrap()
-                .trim_left_matches("0x"); // String
+                .trim_start_matches("0x"); // String
             let output = hex::decode(output).unwrap(); // Bytes
 
             assert_eq!(aggregate_sig.as_bytes(), output);
@@ -634,7 +634,7 @@ mod tests {
 
         // Add each input PublicKey to AggregatePublicKey
         for input in inputs {
-            let pk = input.as_str().unwrap().trim_left_matches("0x"); // String
+            let pk = input.as_str().unwrap().trim_start_matches("0x"); // String
             let pk = hex::decode(pk).unwrap(); // Bytes
             let pk = PublicKey::from_bytes(&pk).unwrap(); // PublicKey
             aggregate_pk.add(&pk);
@@ -644,7 +644,7 @@ mod tests {
         let output = test_case[0]["output"]
             .as_str()
             .unwrap()
-            .trim_left_matches("0x"); // String
+            .trim_start_matches("0x"); // String
         let output = hex::decode(output).unwrap(); // Bytes
 
         assert_eq!(aggregate_pk.as_bytes(), output);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,4 +3,5 @@ pub enum DecodeError {
     BadPoint,
     IncorrectSize,
     Infinity,
+    InvalidCFlag,
 }

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -1,4 +1,4 @@
-use super::amcl_utils::{compress_g1, decompress_g1, GroupG1};
+use super::amcl_utils::{BigNum, compress_g1, decompress_g1, GroupG1};
 use super::errors::DecodeError;
 use std::fmt;
 
@@ -35,6 +35,14 @@ impl G1Point {
 
     pub fn as_raw(&self) -> &GroupG1 {
         &self.point
+    }
+
+    pub fn getx(&mut self) -> BigNum {
+        self.point.getx()
+    }
+
+    pub fn gety(&mut self) -> BigNum {
+        self.point.gety()
     }
 
     /// Instatiate the G1 point from compressed bytes.

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -1,4 +1,4 @@
-use super::amcl_utils::{BigNum, compress_g1, decompress_g1, GroupG1};
+use super::amcl_utils::{compress_g1, decompress_g1, BigNum, GroupG1};
 use super::errors::DecodeError;
 use std::fmt;
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,6 +1,6 @@
 extern crate amcl;
 
-use super::amcl_utils::{ate_pairing, hash_on_g2, map_to_g2, GeneratorG1};
+use super::amcl_utils::{ate_pairing, hash_on_g2, map_to_g2, GENERATORG1};
 use super::errors::DecodeError;
 use super::g2::G2Point;
 use super::keys::{PublicKey, SecretKey};
@@ -39,7 +39,7 @@ impl Signature {
     pub fn verify(&self, msg: &[u8], d: u64, pk: &PublicKey) -> bool {
         let mut msg_hash_point = hash_on_g2(msg, d);
         msg_hash_point.affine();
-        let mut lhs = ate_pairing(self.point.as_raw(), &GeneratorG1);
+        let mut lhs = ate_pairing(self.point.as_raw(), &GENERATORG1);
         let mut rhs = ate_pairing(&msg_hash_point, &pk.point.as_raw());
         lhs.equals(&mut rhs)
     }
@@ -58,7 +58,7 @@ impl Signature {
     ) -> bool {
         let mut msg_hash_point = map_to_g2(msg_hash_real, msg_hash_imaginary);
         msg_hash_point.affine();
-        let mut lhs = ate_pairing(self.point.as_raw(), &GeneratorG1);
+        let mut lhs = ate_pairing(self.point.as_raw(), &GENERATORG1);
         let mut rhs = ate_pairing(&msg_hash_point, &pk.point.as_raw());
         lhs.equals(&mut rhs)
     }
@@ -164,17 +164,17 @@ mod tests {
             let input = test_case["input"].clone();
             // Convert domain from yaml to u64
             let domain = input["domain"].as_str().unwrap();
-            let domain = domain.trim_left_matches("0x");
+            let domain = domain.trim_start_matches("0x");
             let domain = u64::from_str_radix(domain, 16).unwrap();
 
             // Convert msg from yaml to bytes (Vec<u8>)
             let msg = input["message"].as_str().unwrap();
-            let msg = msg.trim_left_matches("0x");
+            let msg = msg.trim_start_matches("0x");
             let msg = hex::decode(msg).unwrap();
 
             // Convert privateKey from yaml to SecretKey
             let privkey = input["privkey"].as_str().unwrap();
-            let privkey = privkey.trim_left_matches("0x");
+            let privkey = privkey.trim_start_matches("0x");
             let mut privkey = hex::decode(privkey).unwrap();
             while privkey.len() < 48 {
                 // Prepend until correct length
@@ -188,7 +188,7 @@ mod tests {
 
             // Convert given output to rust compressed signature (Vec<u8>)
             let output = test_case["output"].as_str().unwrap();
-            let output = output.trim_left_matches("0x");
+            let output = output.trim_start_matches("0x");
             let output = hex::decode(output).unwrap();
 
             assert_eq!(output, compressed_sig);


### PR DESCRIPTION
# Issue

#21 

# Fix
Caused by changing the message signature changing from 
`&Vec<PublicKey>` to `&[&PublicKey]` and
`&Vec<AggregatePublicKey>` to `&[&AggregatePublicKey]`
For certain functions.