### PR TITLE
Use point `equals` method instead of serializing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bls-aggregates"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Lovesh Harchandani <lovesh.bond@gmail.com>"]
 description = "Various signature schemes. BLS, MuSig"
 license = "MIT/Apache-2.0"

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -77,7 +77,8 @@ impl PartialEq for G1Point {
     fn eq(&self, other: &G1Point) -> bool {
         let mut clone_a = self.clone();
         let mut clone_b = other.clone();
-        clone_a.as_bytes() == clone_b.as_bytes()
+
+        clone_a.point.equals(&mut clone_b.point)
     }
 }
 

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -69,7 +69,8 @@ impl PartialEq for G2Point {
     fn eq(&self, other: &G2Point) -> bool {
         let mut clone_a = self.clone();
         let mut clone_b = other.clone();
-        clone_a.as_bytes() == clone_b.as_bytes()
+
+        clone_a.point.equals(&mut clone_b.point)
     }
 }
 


### PR DESCRIPTION
It is much faster to use this method and it seems much more sensible.