### PR TITLE
Optimization for AggregatePublicKey::from_public_keys

### DIFF
--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -32,8 +32,9 @@ impl AggregatePublicKey {
     pub fn from_public_keys(keys: &[&PublicKey]) -> Self {
         let mut agg_key = AggregatePublicKey::new();
         for key in keys {
-            agg_key.add(&key)
+            agg_key.point.add(&key.point)
         }
+        agg_key.point.affine();
         agg_key
     }
 


### PR DESCRIPTION
This reduces the number of times affine is called from `n` to `1`.
It is wasteful to call it so many times when it is only needed once.